### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/image-push-release-rebel.yml
+++ b/.github/workflows/image-push-release-rebel.yml
@@ -70,5 +70,5 @@ jobs:
 
       - name: Create manifest for multi-arch images
         run: |
-          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }} \
-          ${{ env.IMAGE_NAME }}:${{ steps.docker_meta.outputs.tags }}-amd64
+          docker buildx imagetools create -t ${{ steps.docker_meta.outputs.tags }} \
+          ${{ steps.docker_meta.outputs.tags }}-amd64

--- a/.github/workflows/image-push-release-rebel.yml
+++ b/.github/workflows/image-push-release-rebel.yml
@@ -59,6 +59,8 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag
+          flavor: |
+            latest=false
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/image-push-release-rebel.yml
+++ b/.github/workflows/image-push-release-rebel.yml
@@ -32,6 +32,8 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag
+          flavor: |
+            latest=false
 
       - name: Build and push image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
- Prevent docker metadata action from containing `latest` tag in `steps.docker_meta.outputs.tags`
- Remove `env.IMAGE_NAME` from image name since it's already included in `steps.docker_meta.outputs.tags`