### PR TITLE
fix rebellionsInfoProvider and daemonset yaml to be aligned with latest upstream

### DIFF
--- a/deployments/rebel/daemonset.yaml
+++ b/deployments/rebel/daemonset.yaml
@@ -62,7 +62,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: log
           hostPath:
             path: /var/log

--- a/pkg/infoprovider/rebellionsInfoProvider.go
+++ b/pkg/infoprovider/rebellionsInfoProvider.go
@@ -59,7 +59,7 @@ func (rp *rebellionsInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 		HostPath:      devicePath,
 		ContainerPath: devicePath,
-		Permissions:   "rwm",
+		Permissions:   "rw",
 	})
 	return devSpecs
 }


### PR DESCRIPTION
- Change device permission from `rwm` to `rw`
- Mount specific subdirectories under `/var/lib/kubelet/`