### PR TITLE
Add device id selector for ATOM SR-IOV VFs

### DIFF
--- a/deployments/rebel/configmap.yaml
+++ b/deployments/rebel/configmap.yaml
@@ -13,7 +13,7 @@ data:
                 "deviceType": "accelerator",
                 "selectors": {
                     "vendors": ["1eff"],
-                    "devices": ["0010"],
+                    "devices": ["0010", "0011"],
                     "drivers": ["rebellions"]
                 }
             }


### PR DESCRIPTION
ATOM SR-IOV VFs have device id as `1eff:0011`, so updated the configmap to take them into consideration.