### PR TITLE
Feat: support vfio-pci binded devices for kubevirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ $RECYCLE.BIN/
 
 
 # End of https://www.gitignore.io/api/go,macos,linux,windows,visualstudiocode
+.idea

--- a/pkg/accelerator/accelDevice.go
+++ b/pkg/accelerator/accelDevice.go
@@ -35,7 +35,10 @@ func NewAccelDevice(dev *ghw.PCIDevice, rFactory types.ResourceFactory,
 
 	// rebellions: add rebellions info provider
 	if dev.Vendor.ID == infoprovider.RebellionsVendorID {
-		infoProviders = append(infoProviders, infoprovider.NewRebellionsInfoProvider(dev.Address))
+		provider := infoprovider.NewRebellionsInfoProvider(dev.Address, dev.Driver)
+		if provider != nil {
+			infoProviders = append(infoProviders, infoprovider.NewRebellionsInfoProvider(dev.Address, dev.Driver))
+		}
 	}
 
 	hostDev, err := devices.NewHostDeviceImpl(dev, dev.Address, rFactory, rc, infoProviders)

--- a/pkg/resources/pool_stub.go
+++ b/pkg/resources/pool_stub.go
@@ -119,8 +119,13 @@ func (rp *ResourcePoolImpl) GetEnvs(prefix string, deviceIDs []string) (map[stri
 
 	envs := make(map[string]string)
 
+	// construct PCI_RESOURCE_<prefix>_<resource-name> environment variable for kubevirt support
+	key := fmt.Sprintf("%s_%s_%s", "PCI_RESOURCE", prefix, rp.GetResourceName())
+	key = strings.ToUpper(strings.Replace(key, ".", "_", -1))
+	envs[key] = strings.Join(IDList, ",")
+
 	// construct PCIDEVICE_<prefix>_<resource-name> environment variable
-	key := fmt.Sprintf("%s_%s_%s", "PCIDEVICE", prefix, rp.GetResourceName())
+	key = fmt.Sprintf("%s_%s_%s", "PCIDEVICE", prefix, rp.GetResourceName())
 	key = strings.ToUpper(strings.Replace(key, ".", "_", -1))
 	envs[key] = strings.Join(IDList, ",")
 


### PR DESCRIPTION
VFIO PCI 드라이버 바인드 된 디바이스를 할당 할 수 있도록 수정

문제점
1. NewRebellionsInfoProvider에서 바인드된 드라이버에 상관 없이 무조건 "/sys/bus/pci/drivers/rebellions/{pci address}/pools"를 참조하여 deviceID를 가져오고, 저 경로에 일치하는 pci address가 없을 경우  infroProviders Array에 nil을 넣는 이슈 존재.  이로 인해 vfio-pci 디바이스를 컨테이너에 할당할 경우 nil의 메서드를 호출하여 Nil pointer 에러 반환
2. kubevirt에서 host device 할당을 위한 PCI_RESOURCE env 값 부재

해결
1. 드라이버가 vfio-pci인 경우 분기처리하여 기존의 /sys/bus/pci/drivers/rebellions/{pci address}/pools에서 deviceID를 가져오는 방식이 아닌 iommu group 확인을 통한 /dev/vfio/{iommu group}을 마운트
2. PCI_RESOURCE env 값 추가