### PR TITLE
feat: implement PCI topology-aware allocation for Rebellions NPU devices

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -60,12 +60,6 @@ jobs:
 
       - name: Go test with coverage
         run: make test-coverage
-      
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: test/coverage/cover.out
 
   golangci:
     name: Golangci-lint

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ $RECYCLE.BIN/
 
 
 # End of https://www.gitignore.io/api/go,macos,linux,windows,visualstudiocode
+
+.go-version

--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -148,7 +148,7 @@ func (rm *resourceManager) initServers() error {
 			return err
 		}
 		// Create ResourceServer with this ResourcePool
-		s, err := rf.GetResourceServer(rPool)
+		s, err := rf.GetResourceServer(rPool, rc)
 		if err != nil {
 			glog.Errorf("initServers(): error creating ResourceServer: %v", err)
 			return err

--- a/cmd/sriovdp/manager_test.go
+++ b/cmd/sriovdp/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	CDImocks "github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/cdi/mocks"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/factory"
 	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/netdevice"
@@ -30,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestSriovdp(t *testing.T) {
@@ -379,7 +379,7 @@ var _ = Describe("Resource manager", func() {
 						mockedServer.On("Init").Return(fmt.Errorf("fake error"))
 
 						mockedRf := &mocks.ResourceFactory{}
-						mockedRf.On("GetResourceServer", &mocks.ResourcePool{}).
+						mockedRf.On("GetResourceServer", &mocks.ResourcePool{}, mock.AnythingOfType("*types.ResourceConfig")).
 							Return(mockedServer, nil)
 					})
 					It("should not return an error", func() {
@@ -408,7 +408,7 @@ var _ = Describe("Resource manager", func() {
 
 					mockedRf := &mocks.ResourceFactory{}
 					mockedRf.On("GetResourcePool", rc, devs).Return(rp, nil).
-						On("GetResourceServer", rp).Return(mockedServer, nil)
+						On("GetResourceServer", rp, rc).Return(mockedServer, nil)
 					dev.On("GetDeviceID").Return("0000:01:10.0")
 					dp.On("GetDevices", rc, 0).Return(devs)
 					rm := &resourceManager{

--- a/deployments/rebel/configmap.yaml
+++ b/deployments/rebel/configmap.yaml
@@ -11,6 +11,7 @@ data:
                 "resourceName": "ATOM",
                 "resourcePrefix": "rebellions.ai",
                 "deviceType": "accelerator",
+                "allowCrossNuma": true,
                 "selectors": {
                     "vendors": ["1eff"],
                     "devices": [

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -52,13 +52,13 @@ func NewResourceFactory(prefix, suffix string, pluginWatch, useCdi bool) types.R
 }
 
 // GetResourceServer returns an instance of ResourceServer for a ResourcePool
-func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool) (types.ResourceServer, error) {
+func (rf *resourceFactory) GetResourceServer(rp types.ResourcePool, rc *types.ResourceConfig) (types.ResourceServer, error) {
 	if rp != nil {
 		prefix := rf.endPointPrefix
 		if prefixOverride := rp.GetResourcePrefix(); prefixOverride != "" {
 			prefix = prefixOverride
 		}
-		return resources.NewResourceServer(prefix, rf.endPointSuffix, rf.pluginWatch, rf.useCdi, rp), nil
+		return resources.NewResourceServer(prefix, rf.endPointSuffix, rf.pluginWatch, rf.useCdi, rp, rc), nil
 	}
 	return nil, fmt.Errorf("factory: unable to get resource pool object")
 }

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -634,7 +634,7 @@ var _ = Describe("Factory", func() {
 	Describe("getting resource server", func() {
 		Context("when resource pool is nil", func() {
 			f := factory.NewResourceFactory("fake", "fake", true, false)
-			rs, e := f.GetResourceServer(nil)
+			rs, e := f.GetResourceServer(nil, nil)
 			It("should fail", func() {
 				Expect(e).To(HaveOccurred())
 				Expect(rs).To(BeNil())
@@ -645,7 +645,7 @@ var _ = Describe("Factory", func() {
 			rp := mocks.ResourcePool{}
 			rp.On("GetResourcePrefix").Return("overridden").
 				On("GetResourceName").Return("fake")
-			rs, e := f.GetResourceServer(&rp)
+			rs, e := f.GetResourceServer(&rp, nil)
 			It("should not fail", func() {
 				Expect(e).NotTo(HaveOccurred())
 				Expect(rs).NotTo(BeNil())

--- a/pkg/resources/allocator_factory.go
+++ b/pkg/resources/allocator_factory.go
@@ -1,5 +1,7 @@
 package resources
 
+import "github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/types"
+
 const (
 	AtomCA25BridgeIndex          = 2
 	AtomCA25PciBridgeDeviceCount = 4
@@ -10,7 +12,7 @@ const (
 	AtomCA22NumaNodeDeviceCount  = 8
 )
 
-func CreateAllocator(availableDeviceIDs []string, productID string) (Allocator, error) {
+func CreateAllocator(availableDeviceIDs []string, productID string, resourceConfig *types.ResourceConfig) (Allocator, error) {
 	var allocator Allocator
 	var err error
 
@@ -21,6 +23,7 @@ func CreateAllocator(availableDeviceIDs []string, productID string) (Allocator, 
 			AtomCA25BridgeIndex,
 			AtomCA25PciBridgeDeviceCount,
 			AtomCA25NumaNodeDeviceCount,
+			resourceConfig.AllowCrossNuma,
 		)
 		if err != nil {
 			return nil, err
@@ -32,6 +35,7 @@ func CreateAllocator(availableDeviceIDs []string, productID string) (Allocator, 
 			AtomCA22BridgeIndex,
 			AtomCA22PciBridgeDeviceCount,
 			AtomCA22NumaNodeDeviceCount,
+			resourceConfig.AllowCrossNuma,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/resources/allocator_factory.go
+++ b/pkg/resources/allocator_factory.go
@@ -1,0 +1,43 @@
+package resources
+
+const (
+	AtomCA25BridgeIndex          = 2
+	AtomCA25PciBridgeDeviceCount = 4
+	AtomCA25NumaNodeDeviceCount  = 16
+
+	AtomCA22BridgeIndex          = 1
+	AtomCA22PciBridgeDeviceCount = 4
+	AtomCA22NumaNodeDeviceCount  = 8
+)
+
+func CreateAllocator(availableDeviceIDs []string, productID string) (Allocator, error) {
+	var allocator Allocator
+	var err error
+
+	switch productID {
+	case "1251", "1250":
+		allocator, err = NewTopologyAllocator(
+			availableDeviceIDs,
+			AtomCA25BridgeIndex,
+			AtomCA25PciBridgeDeviceCount,
+			AtomCA25NumaNodeDeviceCount,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return allocator, nil
+	case "1221", "1220":
+		allocator, err = NewTopologyAllocator(
+			availableDeviceIDs,
+			AtomCA22BridgeIndex,
+			AtomCA22PciBridgeDeviceCount,
+			AtomCA22NumaNodeDeviceCount,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return allocator, nil
+	default:
+		return &KubeletDelegatingAllocator{productID: productID}, nil
+	}
+}

--- a/pkg/resources/pool_stub.go
+++ b/pkg/resources/pool_stub.go
@@ -119,8 +119,13 @@ func (rp *ResourcePoolImpl) GetEnvs(prefix string, deviceIDs []string) (map[stri
 
 	envs := make(map[string]string)
 
+	// construct PCI_RESOURCE_<prefix>_<resource-name> environment variable for kubevirt support
+	key := fmt.Sprintf("%s_%s_%s", "PCI_RESOURCE", prefix, rp.GetResourceName())
+	key = strings.ToUpper(strings.Replace(key, ".", "_", -1))
+	envs[key] = strings.Join(IDList, ",")
+
 	// construct PCIDEVICE_<prefix>_<resource-name> environment variable
-	key := fmt.Sprintf("%s_%s_%s", "PCIDEVICE", prefix, rp.GetResourceName())
+	key = fmt.Sprintf("%s_%s_%s", "PCIDEVICE", prefix, rp.GetResourceName())
 	key = strings.ToUpper(strings.Replace(key, ".", "_", -1))
 	envs[key] = strings.Join(IDList, ",")
 

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Server", func() {
 			})
 			It("should have the properties correctly assigned when plugin watcher enabled", func() {
 				// Create ResourceServer with plugin watch mode enabled
-				obj := NewResourceServer("fakeprefix", "fakesuffix", true, false, &rp)
+				obj := NewResourceServer("fakeprefix", "fakesuffix", true, false, &rp, nil)
 				rs = obj.(*resourceServer)
 				Expect(rs.resourcePool.GetResourceName()).To(Equal("fakename"))
 				Expect(rs.resourceNamePrefix).To(Equal("fakeprefix"))
@@ -41,7 +41,7 @@ var _ = Describe("Server", func() {
 			})
 			It("should have the properties correctly assigned when plugin watcher disabled", func() {
 				// Create ResourceServer with plugin watch mode disabled
-				obj := NewResourceServer("fakeprefix", "fakesuffix", false, false, &rp)
+				obj := NewResourceServer("fakeprefix", "fakesuffix", false, false, &rp, nil)
 				rs = obj.(*resourceServer)
 				Expect(rs.resourcePool.GetResourceName()).To(Equal("fakename"))
 				Expect(rs.resourceNamePrefix).To(Equal("fakeprefix"))
@@ -67,7 +67,7 @@ var _ = Describe("Server", func() {
 			types.SockDir = fs.RootDir
 			types.DeprecatedSockDir = fs.RootDir
 
-			obj := NewResourceServer("fakeprefix", "fakesuffix", shouldEnablePluginWatch, false, &rp)
+			obj := NewResourceServer("fakeprefix", "fakesuffix", shouldEnablePluginWatch, false, &rp, nil)
 			rs := obj.(*resourceServer)
 
 			registrationServer := createFakeRegistrationServer(fs.RootDir,
@@ -114,7 +114,7 @@ var _ = Describe("Server", func() {
 				defer fs.Use()()
 				rp := mocks.ResourcePool{}
 				rp.On("GetResourceName").Return("fake.com")
-				rs := NewResourceServer("fakeprefix", "fakesuffix", true, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fakeprefix", "fakesuffix", true, false, &rp, nil).(*resourceServer)
 				err = rs.Init()
 			})
 			It("should never fail", func() {
@@ -154,7 +154,7 @@ var _ = Describe("Server", func() {
 					On("CleanDeviceInfoFile", "fake").Return(nil)
 
 				// Create ResourceServer with plugin watch mode disabled
-				rs := NewResourceServer("fake", "fake", false, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake", "fake", false, false, &rp, nil).(*resourceServer)
 
 				registrationServer := createFakeRegistrationServer(fs.RootDir,
 					"fake_fake.com.fake", false, false)
@@ -194,7 +194,7 @@ var _ = Describe("Server", func() {
 					On("Probe").Return(true).
 					On("CleanDeviceInfoFile", "fake").Return(nil)
 				// Create ResourceServer with plugin watch mode enabled
-				rs := NewResourceServer("fake", "fake", true, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake", "fake", true, false, &rp, nil).(*resourceServer)
 
 				registrationServer := createFakeRegistrationServer(fs.RootDir,
 					"fake_fake.com.fake", false, true)
@@ -229,7 +229,7 @@ var _ = Describe("Server", func() {
 					On("CleanDeviceInfoFile", "fake").Return(nil)
 
 				// Create ResourceServer with plugin watch mode disabled
-				rs := NewResourceServer("fake", "fake", false, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake", "fake", false, false, &rp, nil).(*resourceServer)
 
 				registrationServer := createFakeRegistrationServer(fs.RootDir,
 					"fake_fake.com.fake", false, false)
@@ -273,7 +273,7 @@ var _ = Describe("Server", func() {
 				On("StoreDeviceInfoFile", "fake.com", []string{"00:00.01"}).
 				Return(nil)
 
-			rs := NewResourceServer("fake.com", "fake", true, false, &rp).(*resourceServer)
+			rs := NewResourceServer("fake.com", "fake", true, false, &rp, nil).(*resourceServer)
 
 			resp, err := rs.Allocate(context.TODO(), req)
 
@@ -319,7 +319,7 @@ var _ = Describe("Server", func() {
 				On("StoreDeviceInfoFile", "fake.com", []string{"00:00.01"}).
 				Return(nil)
 
-			rs := NewResourceServer("fake.com", "fake", true, true, &rp).(*resourceServer)
+			rs := NewResourceServer("fake.com", "fake", true, true, &rp, nil).(*resourceServer)
 
 			cdi := &CDImocks.CDI{}
 			cdi.On("CreateCDISpecForPool", "fake.com", &rp).Return(nil).Twice().
@@ -378,7 +378,7 @@ var _ = Describe("Server", func() {
 				rp.On("GetResourceName").Return("fake.com").
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.01": {ID: "00:00.01", Health: "Healthy"}}).Once()
 
-				rs := NewResourceServer("fake.com", "fake", true, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake.com", "fake", true, false, &rp, nil).(*resourceServer)
 				rs.sockPath = fs.RootDir
 
 				lwSrv := &fakeListAndWatchServer{
@@ -399,7 +399,7 @@ var _ = Describe("Server", func() {
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.01": {ID: "00:00.01", Health: "Healthy"}}).Once().
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.02": {ID: "00:00.02", Health: "Healthy"}}).Once()
 
-				rs := NewResourceServer("fake.com", "fake", true, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake.com", "fake", true, false, &rp, nil).(*resourceServer)
 				rs.sockPath = fs.RootDir
 
 				lwSrv := &fakeListAndWatchServer{
@@ -434,7 +434,7 @@ var _ = Describe("Server", func() {
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.01": {ID: "00:00.01", Health: "Healthy"}}).Once().
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.02": {ID: "00:00.02", Health: "Healthy"}}).Once()
 
-				rs := NewResourceServer("fake.com", "fake", true, false, &rp).(*resourceServer)
+				rs := NewResourceServer("fake.com", "fake", true, false, &rp, nil).(*resourceServer)
 				rs.sockPath = fs.RootDir
 
 				lwSrv := &fakeListAndWatchServer{
@@ -472,7 +472,7 @@ var _ = Describe("Server", func() {
 					On("GetDevices").Return(map[string]*pluginapi.Device{"00:00.01": {ID: "00:00.01", Health: "Healthy"}}).Twice().
 					On("GetResourcePrefix").Return("fake.com").Twice()
 
-				rs := NewResourceServer("fake.com", "fake", true, true, &rp).(*resourceServer)
+				rs := NewResourceServer("fake.com", "fake", true, true, &rp, nil).(*resourceServer)
 				rs.sockPath = fs.RootDir
 
 				cdi := &CDImocks.CDI{}

--- a/pkg/resources/topology_allocator.go
+++ b/pkg/resources/topology_allocator.go
@@ -1,0 +1,106 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/utils"
+)
+
+type NUMANode int
+
+type BridgeID string
+
+type TopologyAllocator struct {
+	NodeTopology *NodeTopology
+}
+
+// PCIBridgeGroup represents devices connected to the same PCI bridge
+type PCIBridgeGroup struct {
+	DeviceIDs []string // Device IDs connected to this switch
+}
+
+// NUMATopology represents NUMA node topology information
+type NUMATopology struct {
+	PCIBridges map[BridgeID]*PCIBridgeGroup // PCI bridges in this NUMA node
+}
+
+// NodeTopology represents the complete topology information of a node
+type NodeTopology struct {
+	NUMANodes map[NUMANode]*NUMATopology // NUMA nodes in this node
+}
+
+func NewTopologyAllocator(availableDeviceIDs []string) (*TopologyAllocator, error) {
+	topology := &NodeTopology{
+		NUMANodes: make(map[NUMANode]*NUMATopology),
+	}
+
+	for _, deviceID := range availableDeviceIDs {
+		numaNode := utils.GetDevNode(deviceID)
+		pciSwitch, err := utils.GetPCIBridge(deviceID)
+		if err != nil {
+			glog.Errorf("Failed to get PCI switch for device %s: %v", deviceID, err)
+			return nil, err
+		}
+
+		if _, exists := topology.NUMANodes[NUMANode(numaNode)]; !exists {
+			topology.NUMANodes[NUMANode(numaNode)] = &NUMATopology{
+				PCIBridges: make(map[BridgeID]*PCIBridgeGroup),
+			}
+		}
+
+		if _, exists := topology.NUMANodes[NUMANode(numaNode)].PCIBridges[BridgeID(pciSwitch)]; !exists {
+			topology.NUMANodes[NUMANode(numaNode)].PCIBridges[BridgeID(pciSwitch)] = &PCIBridgeGroup{
+				DeviceIDs: make([]string, 0),
+			}
+		}
+
+		topology.NUMANodes[NUMANode(numaNode)].PCIBridges[BridgeID(pciSwitch)].DeviceIDs = append(
+			topology.NUMANodes[NUMANode(numaNode)].PCIBridges[BridgeID(pciSwitch)].DeviceIDs,
+			deviceID,
+		)
+	}
+
+	return &TopologyAllocator{NodeTopology: topology}, nil
+}
+
+func (ta *TopologyAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
+	result := make([]string, 0, allocationSize)
+
+	// Find allocationSize devices on the same PCI bridge
+	for _, numaNode := range ta.NodeTopology.NUMANodes {
+		for _, bridge := range numaNode.PCIBridges {
+			if len(bridge.DeviceIDs) >= allocationSize {
+				for i := 0; i < allocationSize; i++ {
+					result = append(result, bridge.DeviceIDs[i])
+				}
+				glog.Infof("Selected %d devices from same PCI bridge", allocationSize)
+				return result, nil
+			}
+		}
+	}
+
+	// Find allocationSize devices within the same NUMA node
+	for _, numaNode := range ta.NodeTopology.NUMANodes {
+		availableDevices := ta.getAllDevicesFromNUMA(numaNode)
+		if len(availableDevices) >= allocationSize {
+			for i := 0; i < allocationSize; i++ {
+				result = append(result, availableDevices[i])
+			}
+			glog.Infof("Selected %d devices from same NUMA node", allocationSize)
+			return result, nil
+		}
+	}
+
+	// 3. Unable to find enough devices – delegate allocation decision to the kubelet
+	return nil, fmt.Errorf("insufficient devices for topology-aware allocation: need %d, available topology cannot satisfy", allocationSize)
+}
+
+// getAllDevicesFromNUMA returns all devices from a NUMA node
+func (ta *TopologyAllocator) getAllDevicesFromNUMA(numaNode *NUMATopology) []string {
+	var devices []string
+	for _, bridge := range numaNode.PCIBridges {
+		devices = append(devices, bridge.DeviceIDs...)
+	}
+	return devices
+}

--- a/pkg/resources/topology_allocator.go
+++ b/pkg/resources/topology_allocator.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/golang/glog"
 	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/utils"
@@ -10,6 +11,10 @@ import (
 type NUMANode int
 
 type BridgeID string
+
+type Allocator interface {
+	SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error)
+}
 
 type TopologyAllocator struct {
 	NodeTopology *NodeTopology
@@ -27,17 +32,47 @@ type NUMATopology struct {
 
 // NodeTopology represents the complete topology information of a node
 type NodeTopology struct {
-	NUMANodes map[NUMANode]*NUMATopology // NUMA nodes in this node
+	NUMANodes            map[NUMANode]*NUMATopology // NUMA nodes in this node
+	PciBridgeDeviceCount int
+	NumaNodeDeviceCount  int
 }
 
-func NewTopologyAllocator(availableDeviceIDs []string) (*TopologyAllocator, error) {
+type bridgeInfo struct {
+	id      BridgeID
+	free    int
+	devices []string
+}
+
+type AllocationResult struct {
+	selectedDevices        []string
+	fullyFilledBridgeCount int
+	deviceRemaining        int
+}
+
+type KubeletDelegatingAllocator struct {
+	productID string
+}
+
+func (a *KubeletDelegatingAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
+	return nil, fmt.Errorf(
+		"topology-aware allocation not supported for this product: %s, kubelet should handle device allocation",
+		a.productID,
+	)
+}
+
+func NewTopologyAllocator(
+	availableDeviceIDs []string,
+	bridgeIndex, pciBridgeDeviceCount, numaNodeDeviceCount int,
+) (*TopologyAllocator, error) {
 	topology := &NodeTopology{
-		NUMANodes: make(map[NUMANode]*NUMATopology),
+		NUMANodes:            make(map[NUMANode]*NUMATopology),
+		PciBridgeDeviceCount: pciBridgeDeviceCount,
+		NumaNodeDeviceCount:  numaNodeDeviceCount,
 	}
 
 	for _, deviceID := range availableDeviceIDs {
 		numaNode := utils.GetDevNode(deviceID)
-		pciSwitch, err := utils.GetPCIBridge(deviceID)
+		pciSwitch, err := utils.GetPCIBridge(deviceID, bridgeIndex)
 		if err != nil {
 			glog.Errorf("Failed to get PCI switch for device %s: %v", deviceID, err)
 			return nil, err
@@ -64,43 +99,225 @@ func NewTopologyAllocator(availableDeviceIDs []string) (*TopologyAllocator, erro
 	return &TopologyAllocator{NodeTopology: topology}, nil
 }
 
-func (ta *TopologyAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
-	result := make([]string, 0, allocationSize)
+func selectOptimalNUMANode(ta *TopologyAllocator, allocationSize int) (*NUMATopology, error) {
+	var selectedNUMA *NUMATopology
+	minDeviceCountDiff := int(^uint(0) >> 1)
 
-	// Find allocationSize devices on the same PCI bridge
 	for _, numaNode := range ta.NodeTopology.NUMANodes {
-		for _, bridge := range numaNode.PCIBridges {
-			if len(bridge.DeviceIDs) >= allocationSize {
-				for i := 0; i < allocationSize; i++ {
-					result = append(result, bridge.DeviceIDs[i])
-				}
-				glog.Infof("Selected %d devices from same PCI bridge", allocationSize)
-				return result, nil
+		numaDevices := ta.getAllDevicesFromNUMA(numaNode)
+		availableDeviceCount := len(numaDevices)
+
+		if availableDeviceCount >= allocationSize {
+			deviceCountDiff := availableDeviceCount - allocationSize
+			if deviceCountDiff < minDeviceCountDiff {
+				minDeviceCountDiff = deviceCountDiff
+				selectedNUMA = numaNode
 			}
 		}
 	}
 
-	// Find allocationSize devices within the same NUMA node
-	for _, numaNode := range ta.NodeTopology.NUMANodes {
-		availableDevices := ta.getAllDevicesFromNUMA(numaNode)
-		if len(availableDevices) >= allocationSize {
-			for i := 0; i < allocationSize; i++ {
-				result = append(result, availableDevices[i])
-			}
-			glog.Infof("Selected %d devices from same NUMA node", allocationSize)
-			return result, nil
-		}
+	if selectedNUMA == nil {
+		return nil, fmt.Errorf("no NUMA node with sufficient devices (>= %d) found, topology-aware allocation failed", allocationSize)
 	}
-
-	// 3. Unable to find enough devices – delegate allocation decision to the kubelet
-	return nil, fmt.Errorf("insufficient devices for topology-aware allocation: need %d, available topology cannot satisfy", allocationSize)
+	return selectedNUMA, nil
 }
 
-// getAllDevicesFromNUMA returns all devices from a NUMA node
-func (ta *TopologyAllocator) getAllDevicesFromNUMA(numaNode *NUMATopology) []string {
-	var devices []string
-	for _, bridge := range numaNode.PCIBridges {
-		devices = append(devices, bridge.DeviceIDs...)
+func prepareBridgesSortedByCapacity(selectedNUMA *NUMATopology) []bridgeInfo {
+	bridgeList := make([]bridgeInfo, 0)
+	for bridgeID, bridgeGroup := range selectedNUMA.PCIBridges {
+		bridgeList = append(bridgeList, bridgeInfo{
+			id:      bridgeID,
+			free:    len(bridgeGroup.DeviceIDs),
+			devices: bridgeGroup.DeviceIDs,
+		})
 	}
-	return devices
+	sort.Slice(bridgeList, func(i, j int) bool {
+		return bridgeList[i].free > bridgeList[j].free
+	})
+	return bridgeList
+}
+
+func (ta *TopologyAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
+	if allocationSize > ta.NodeTopology.NumaNodeDeviceCount {
+		return nil, fmt.Errorf(
+			"allocation size %d exceeds NUMA node capacity %d, topology-aware allocation not beneficial, kubelet should handle allocation",
+			allocationSize,
+			ta.NodeTopology.NumaNodeDeviceCount,
+		)
+	}
+
+	optimalNUMA, err := selectOptimalNUMANode(ta, allocationSize)
+	if err != nil {
+		return nil, err
+	}
+
+	glog.Infof("Selected NUMA node with %d free devices for allocation of %d", len(ta.getAllDevicesFromNUMA(optimalNUMA)), allocationSize)
+
+	bridgeList := prepareBridgesSortedByCapacity(optimalNUMA)
+
+	glog.Infof("Starting optimal allocation: need %d devices from %d bridges", allocationSize, len(bridgeList))
+
+	allocationResult := findOptimalBridgeAllocation(bridgeList, allocationSize)
+	if allocationResult == nil {
+		return nil, fmt.Errorf("optimal allocation failed: no valid bridge combination found")
+	}
+
+	glog.Infof("Selecting Devices completed: selected devices: %v", allocationResult.selectedDevices)
+
+	return allocationResult.selectedDevices, nil
+}
+
+func (ta *TopologyAllocator) getAllDevicesFromNUMA(numaNode *NUMATopology) []string {
+	var allDeviceIDs []string
+	for _, bridgeGroup := range numaNode.PCIBridges {
+		allDeviceIDs = append(allDeviceIDs, bridgeGroup.DeviceIDs...)
+	}
+	return allDeviceIDs
+}
+
+func findOptimalBridgeAllocation(bridgeList []bridgeInfo, allocationSize int) *AllocationResult {
+	for bridgeCount := 1; bridgeCount <= len(bridgeList); bridgeCount++ {
+		glog.Infof("Trying allocation with %d bridges", bridgeCount)
+
+		if allocationResult := findBestAllocationWithNBridges(bridgeList, allocationSize, bridgeCount); allocationResult != nil {
+			return allocationResult
+		}
+	}
+	return nil
+}
+
+func findBestAllocationWithNBridges(bridgeList []bridgeInfo, allocationSize, bridgeCount int) *AllocationResult {
+	var bestAllocation *AllocationResult
+
+	bridgeCombinations := generateBridgeCombinations(bridgeList, bridgeCount)
+
+	for _, bridgeCombination := range bridgeCombinations {
+		totalAvailableDevices := 0
+		for _, bridge := range bridgeCombination {
+			totalAvailableDevices += bridge.free
+		}
+
+		if totalAvailableDevices < allocationSize {
+			continue
+		}
+
+		allocationResult := simulateDeviceAllocation(bridgeCombination, allocationSize)
+		if allocationResult != nil {
+			if isAllocationBetter(allocationResult, bestAllocation) {
+				bestAllocation = allocationResult
+			}
+		}
+	}
+
+	return bestAllocation
+}
+
+func generateBridgeCombinations(bridgeList []bridgeInfo, targetBridgeCount int) [][]bridgeInfo {
+	var combinationResults [][]bridgeInfo
+
+	var backtrackCombinations func(startIndex int, currentCombination []bridgeInfo)
+	backtrackCombinations = func(startIndex int, currentCombination []bridgeInfo) {
+		if len(currentCombination) == targetBridgeCount {
+			bridgeCombination := make([]bridgeInfo, len(currentCombination))
+			copy(bridgeCombination, currentCombination)
+			combinationResults = append(combinationResults, bridgeCombination)
+			return
+		}
+
+		for bridgeIndex := startIndex; bridgeIndex < len(bridgeList); bridgeIndex++ {
+			currentCombination = append(currentCombination, bridgeList[bridgeIndex])
+			backtrackCombinations(bridgeIndex+1, currentCombination)
+			currentCombination = currentCombination[:len(currentCombination)-1]
+		}
+	}
+
+	backtrackCombinations(0, []bridgeInfo{})
+	return combinationResults
+}
+
+func simulateDeviceAllocation(selectedBridges []bridgeInfo, allocationSize int) *AllocationResult {
+	sort.Slice(selectedBridges, func(i, j int) bool {
+		return selectedBridges[i].free > selectedBridges[j].free
+	})
+
+	if isTotalCapacityExactMatch(selectedBridges, allocationSize) {
+		return handleExactCapacityMatch(selectedBridges)
+	}
+
+	return handlePartialBridgeAllocation(selectedBridges, allocationSize)
+}
+
+func isTotalCapacityExactMatch(selectedBridges []bridgeInfo, allocationSize int) bool {
+	totalBridgeCapacity := 0
+	for _, bridge := range selectedBridges {
+		totalBridgeCapacity += bridge.free
+	}
+	return totalBridgeCapacity == allocationSize
+}
+
+func handleExactCapacityMatch(selectedBridges []bridgeInfo) *AllocationResult {
+	var allocatedDevices []string
+
+	for _, bridge := range selectedBridges {
+		allocatedDevices = append(allocatedDevices, bridge.devices...)
+	}
+
+	return &AllocationResult{
+		selectedDevices:        allocatedDevices,
+		fullyFilledBridgeCount: len(selectedBridges),
+		deviceRemaining:        0,
+	}
+}
+
+func handlePartialBridgeAllocation(selectedBridges []bridgeInfo, allocationSize int) *AllocationResult {
+	var allocatedDevices []string
+	remainingToAllocate := allocationSize
+	bridgesFullyFilled := 0
+	devicesRemainingInPartialBridge := 0
+
+	for bridgeIndex, bridge := range selectedBridges {
+		if bridge.free <= remainingToAllocate {
+			// Use entire bridge capacity
+			allocatedDevices = append(allocatedDevices, bridge.devices...)
+			remainingToAllocate -= bridge.free
+			bridgesFullyFilled++
+		} else {
+			// Partial allocation needed - find smallest suitable bridge
+			optimalPartialBridge := findSmallestSuitableBridge(selectedBridges, bridgeIndex, remainingToAllocate)
+			allocatedDevices = append(allocatedDevices, optimalPartialBridge.devices[:remainingToAllocate]...)
+			devicesRemainingInPartialBridge = optimalPartialBridge.free - remainingToAllocate
+			break
+		}
+	}
+
+	return &AllocationResult{
+		selectedDevices:        allocatedDevices,
+		fullyFilledBridgeCount: bridgesFullyFilled,
+		deviceRemaining:        devicesRemainingInPartialBridge,
+	}
+}
+
+func findSmallestSuitableBridge(bridgeCandidates []bridgeInfo, searchStartIndex, requiredCapacity int) bridgeInfo {
+	optimalBridge := bridgeCandidates[searchStartIndex]
+
+	for candidateIndex := searchStartIndex + 1; candidateIndex < len(bridgeCandidates); candidateIndex++ {
+		candidate := bridgeCandidates[candidateIndex]
+		if candidate.free < optimalBridge.free && candidate.free >= requiredCapacity {
+			optimalBridge = candidate
+		}
+	}
+
+	return optimalBridge
+}
+
+func isAllocationBetter(candidateAllocation, currentBestAllocation *AllocationResult) bool {
+	if currentBestAllocation == nil {
+		return true
+	}
+
+	if candidateAllocation.fullyFilledBridgeCount != currentBestAllocation.fullyFilledBridgeCount {
+		return candidateAllocation.fullyFilledBridgeCount > currentBestAllocation.fullyFilledBridgeCount
+	}
+
+	return candidateAllocation.deviceRemaining > currentBestAllocation.deviceRemaining
 }

--- a/pkg/resources/topology_allocator.go
+++ b/pkg/resources/topology_allocator.go
@@ -8,6 +8,23 @@ import (
 	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/utils"
 )
 
+// Custom error types for allocation control
+type CrossNUMAAllocationError struct {
+	message string
+}
+
+func (e *CrossNUMAAllocationError) Error() string {
+	return e.message
+}
+
+type NonRebellionsDeviceError struct {
+	productID string
+}
+
+func (e *NonRebellionsDeviceError) Error() string {
+	return fmt.Sprintf("topology-aware allocation not supported for this product: %s, kubelet should handle device allocation", e.productID)
+}
+
 type NUMANode int
 
 type BridgeID string
@@ -17,7 +34,8 @@ type Allocator interface {
 }
 
 type TopologyAllocator struct {
-	NodeTopology *NodeTopology
+	NodeTopology   *NodeTopology
+	AllowCrossNuma bool
 }
 
 // PCIBridgeGroup represents devices connected to the same PCI bridge
@@ -54,15 +72,13 @@ type KubeletDelegatingAllocator struct {
 }
 
 func (a *KubeletDelegatingAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
-	return nil, fmt.Errorf(
-		"topology-aware allocation not supported for this product: %s, kubelet should handle device allocation",
-		a.productID,
-	)
+	return nil, &NonRebellionsDeviceError{productID: a.productID}
 }
 
 func NewTopologyAllocator(
 	availableDeviceIDs []string,
 	bridgeIndex, pciBridgeDeviceCount, numaNodeDeviceCount int,
+	allowCrossNuma bool,
 ) (*TopologyAllocator, error) {
 	topology := &NodeTopology{
 		NUMANodes:            make(map[NUMANode]*NUMATopology),
@@ -96,21 +112,20 @@ func NewTopologyAllocator(
 		)
 	}
 
-	return &TopologyAllocator{NodeTopology: topology}, nil
+	return &TopologyAllocator{NodeTopology: topology, AllowCrossNuma: allowCrossNuma}, nil
 }
 
 func selectOptimalNUMANode(ta *TopologyAllocator, allocationSize int) (*NUMATopology, error) {
 	var selectedNUMA *NUMATopology
-	minDeviceCountDiff := int(^uint(0) >> 1)
+	maxDeviceCount := -1
 
 	for _, numaNode := range ta.NodeTopology.NUMANodes {
 		numaDevices := ta.getAllDevicesFromNUMA(numaNode)
 		availableDeviceCount := len(numaDevices)
 
 		if availableDeviceCount >= allocationSize {
-			deviceCountDiff := availableDeviceCount - allocationSize
-			if deviceCountDiff < minDeviceCountDiff {
-				minDeviceCountDiff = deviceCountDiff
+			if availableDeviceCount > maxDeviceCount {
+				maxDeviceCount = availableDeviceCount
 				selectedNUMA = numaNode
 			}
 		}
@@ -138,35 +153,108 @@ func prepareBridgesSortedByCapacity(selectedNUMA *NUMATopology) []bridgeInfo {
 }
 
 func (ta *TopologyAllocator) SelectDevices(mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
-	if allocationSize > ta.NodeTopology.NumaNodeDeviceCount {
-		return nil, fmt.Errorf(
-			"allocation size %d exceeds NUMA node capacity %d, topology-aware allocation not beneficial, kubelet should handle allocation",
-			allocationSize,
-			ta.NodeTopology.NumaNodeDeviceCount,
-		)
+	if allocationSize > ta.NodeTopology.NumaNodeDeviceCount || ta.AllowCrossNuma {
+		glog.Infof("Cross-NUMA allocation triggered for %d devices (single NUMA capacity: %d)",
+			allocationSize, ta.NodeTopology.NumaNodeDeviceCount)
+		return ta.selectDevicesFromMultipleNUMA(allocationSize), nil
 	}
 
 	optimalNUMA, err := selectOptimalNUMANode(ta, allocationSize)
 	if err != nil {
-		return nil, err
+		// Return cross-NUMA allocation error to prevent kubelet from handling allocation
+		return nil, &CrossNUMAAllocationError{
+			message: fmt.Sprintf("cross-NUMA allocation not possible: %v", err),
+		}
 	}
 
-	glog.Infof("Selected NUMA node with %d free devices for allocation of %d", len(ta.getAllDevicesFromNUMA(optimalNUMA)), allocationSize)
+	return ta.selectDevicesFromNUMA(optimalNUMA, allocationSize), nil
+}
 
-	bridgeList := prepareBridgesSortedByCapacity(optimalNUMA)
+// selectDevicesFromNUMA selects devices from a specific NUMA node with the given allocation size
+func (ta *TopologyAllocator) selectDevicesFromNUMA(numaTopology *NUMATopology, allocationSize int) []string {
+	glog.Infof("Selected NUMA node with %d free devices for allocation of %d", len(ta.getAllDevicesFromNUMA(numaTopology)), allocationSize)
+
+	bridgeList := prepareBridgesSortedByCapacity(numaTopology)
 
 	glog.Infof("Starting optimal allocation: need %d devices from %d bridges", allocationSize, len(bridgeList))
 
 	allocationResult := findOptimalBridgeAllocation(bridgeList, allocationSize)
-	if allocationResult == nil {
-		return nil, fmt.Errorf("optimal allocation failed: no valid bridge combination found")
-	}
 
 	glog.Infof("Selecting Devices completed: selected devices: %v", allocationResult.selectedDevices)
 
-	return allocationResult.selectedDevices, nil
+	return allocationResult.selectedDevices
 }
 
+// selectDevicesFromMultipleNUMA allocates devices across multiple NUMA nodes, prioritizing nodes with fewer devices
+func (ta *TopologyAllocator) selectDevicesFromMultipleNUMA(allocationSize int) []string {
+	glog.Infof("Starting cross-NUMA allocation for %d devices", allocationSize)
+
+	// Get all NUMA nodes sorted by device count (descending - largest first)
+	sortedNUMANodes := ta.getNUMANodesSortedByDeviceCount()
+
+	var allSelectedDevices []string
+	remainingAllocation := allocationSize
+
+	for _, numaEntry := range sortedNUMANodes {
+		if remainingAllocation <= 0 {
+			break
+		}
+
+		allocationFromThisNUMA := min(remainingAllocation, numaEntry.deviceCount)
+
+		glog.Infof("Allocating %d devices from NUMA node %d (has %d available)",
+			allocationFromThisNUMA, numaEntry.numaNode, numaEntry.deviceCount)
+
+		devices := ta.selectDevicesFromNUMA(numaEntry.topology, allocationFromThisNUMA)
+
+		allSelectedDevices = append(allSelectedDevices, devices...)
+		remainingAllocation -= len(devices)
+
+		glog.Infof("Successfully allocated %d devices from NUMA node %d, remaining: %d",
+			len(devices), numaEntry.numaNode, remainingAllocation)
+	}
+
+	glog.Infof("Cross-NUMA allocation completed: selected %d devices across multiple NUMA nodes", len(allSelectedDevices))
+	return allSelectedDevices
+}
+
+// numaNodeEntry represents a NUMA node with its device count for sorting
+type numaNodeEntry struct {
+	numaNode    NUMANode
+	topology    *NUMATopology
+	deviceCount int
+}
+
+// getNUMANodesSortedByDeviceCount returns NUMA nodes sorted by device count (descending)
+func (ta *TopologyAllocator) getNUMANodesSortedByDeviceCount() []numaNodeEntry {
+	numaEntries := make([]numaNodeEntry, 0, len(ta.NodeTopology.NUMANodes))
+
+	for numaNode, topology := range ta.NodeTopology.NUMANodes {
+		deviceCount := len(ta.getAllDevicesFromNUMA(topology))
+		numaEntries = append(numaEntries, numaNodeEntry{
+			numaNode:    numaNode,
+			topology:    topology,
+			deviceCount: deviceCount,
+		})
+	}
+
+	// Sort by device count (descending - nodes with more devices first)
+	sort.Slice(numaEntries, func(i, j int) bool {
+		return numaEntries[i].deviceCount > numaEntries[j].deviceCount
+	})
+
+	return numaEntries
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// getAllDevicesFromNUMA returns all device IDs from a NUMA node
 func (ta *TopologyAllocator) getAllDevicesFromNUMA(numaNode *NUMATopology) []string {
 	var allDeviceIDs []string
 	for _, bridgeGroup := range numaNode.PCIBridges {

--- a/pkg/resources/topology_allocator_test.go
+++ b/pkg/resources/topology_allocator_test.go
@@ -9,36 +9,62 @@ import (
 
 var _ = Describe("TopologyAllocator", func() {
 
-	// Helper function to create test topology with specified bridge capacities
-	createTestTopologyWithBridges := func(bridgeCapacities []int) *TopologyAllocator {
+	// Unified helper function to create test topology
+	createTestTopology := func(numaConfigs map[int][]int, pciBridgeDeviceCount, numaNodeDeviceCount int) *TopologyAllocator {
 		topology := &NodeTopology{
 			NUMANodes:            make(map[NUMANode]*NUMATopology),
-			PciBridgeDeviceCount: 10,  // Default bridge capacity
-			NumaNodeDeviceCount:  100, // Large enough to not interfere with tests
-		}
-
-		numaTopology := &NUMATopology{
-			PCIBridges: make(map[BridgeID]*PCIBridgeGroup),
+			PciBridgeDeviceCount: pciBridgeDeviceCount,
+			NumaNodeDeviceCount:  numaNodeDeviceCount,
 		}
 
 		deviceCounter := 0
-		for bridgeIdx, capacity := range bridgeCapacities {
-			bridgeID := BridgeID(fmt.Sprintf("bridge%d", bridgeIdx))
-			deviceIDs := make([]string, capacity)
-
-			for i := 0; i < capacity; i++ {
-				deviceIDs[i] = fmt.Sprintf("device%d", deviceCounter)
-				deviceCounter++
+		for numaIdx, bridgeCapacities := range numaConfigs {
+			numaTopology := &NUMATopology{
+				PCIBridges: make(map[BridgeID]*PCIBridgeGroup),
 			}
 
-			numaTopology.PCIBridges[bridgeID] = &PCIBridgeGroup{
-				DeviceIDs: deviceIDs,
+			for bridgeIdx, capacity := range bridgeCapacities {
+				bridgeID := BridgeID(fmt.Sprintf("bridge%d", bridgeIdx))
+				deviceIDs := make([]string, capacity)
+
+				for i := 0; i < capacity; i++ {
+					if len(numaConfigs) == 1 {
+						// Single NUMA mode - use simple device ID
+						deviceIDs[i] = fmt.Sprintf("device%d", deviceCounter)
+					} else {
+						// Multi-NUMA mode - include NUMA index in device ID
+						deviceIDs[i] = fmt.Sprintf("numa%d_device%d", numaIdx, deviceCounter)
+					}
+					deviceCounter++
+				}
+
+				numaTopology.PCIBridges[bridgeID] = &PCIBridgeGroup{
+					DeviceIDs: deviceIDs,
+				}
 			}
+
+			topology.NUMANodes[NUMANode(numaIdx)] = numaTopology
 		}
 
-		topology.NUMANodes[NUMANode(0)] = numaTopology
-
 		return &TopologyAllocator{NodeTopology: topology}
+	}
+
+	// Convenience wrapper for single NUMA tests (backward compatibility)
+	createTestTopologyWithBridges := func(bridgeCapacities []int) *TopologyAllocator {
+		numaConfigs := map[int][]int{0: bridgeCapacities}
+		return createTestTopology(numaConfigs, 10, 100)
+	}
+
+	// Convenience wrapper for multi-NUMA tests
+	createTestTopologyWithMultipleNUMA := func(numaConfigs map[int][]int) *TopologyAllocator {
+		return createTestTopology(numaConfigs, 10, 6) // NumaNodeDeviceCount를 6으로 변경
+	}
+
+	// Helper function to create test topology with AllowCrossNuma setting
+	createTestTopologyWithCrossNUMA := func(numaConfigs map[int][]int, allowCrossNuma bool) *TopologyAllocator {
+		allocator := createTestTopology(numaConfigs, 10, 6)
+		allocator.AllowCrossNuma = allowCrossNuma
+		return allocator
 	}
 
 	// Helper function to get bridge assignment of selected devices
@@ -208,6 +234,158 @@ var _ = Describe("TopologyAllocator", func() {
 		})
 	})
 
+	Describe("Cross-NUMA Allocation", func() {
+		// Helper function to count devices per NUMA node in result
+		countDevicesPerNUMA := func(selectedDevices []string) map[int]int {
+			numaCount := make(map[int]int)
+			for _, deviceID := range selectedDevices {
+				// Extract NUMA node index from device ID (numa0_device1 -> 0)
+				var numaIdx int
+				fmt.Sscanf(deviceID, "numa%d_device%d", &numaIdx, new(int))
+				numaCount[numaIdx]++
+			}
+			return numaCount
+		}
+
+		Context("when allocation size exceeds single NUMA capacity", func() {
+			It("should allocate across multiple NUMA nodes starting from smallest", func() {
+				// NUMA 0: 4 devices, NUMA 1: 6 devices, NUMA 2: 8 devices
+				// For allocation size 10 (> 8), should prioritize NUMA 0 (smallest) first
+				numaConfigs := map[int][]int{
+					0: {2, 2}, // NUMA 0: 4 devices total
+					1: {3, 3}, // NUMA 1: 6 devices total
+					2: {4, 4}, // NUMA 2: 8 devices total
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 10)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(10))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				// Should use all 4 devices from NUMA 0 (smallest), then 6 from NUMA 1
+				Expect(numaCount[2]).To(Equal(8), "Should use all devices from NUMA 2")
+				Expect(numaCount[1]).To(Equal(2), "Should use 2 devices from NUMA 1")
+				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+			})
+
+			It("should handle exact cross-NUMA allocation", func() {
+				// NUMA 0: 3 devices, NUMA 1: 5 devices
+				// For allocation size 8, should use all devices from both NUMA nodes
+				numaConfigs := map[int][]int{
+					0: {3}, // NUMA 0: 3 devices
+					1: {5}, // NUMA 1: 5 devices
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 8)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(8))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				Expect(numaCount[0]).To(Equal(3), "Should use all 3 devices from NUMA 0")
+				Expect(numaCount[1]).To(Equal(5), "Should use all 5 devices from NUMA 1")
+			})
+
+			It("should handle partial allocation from multiple NUMA nodes", func() {
+				// NUMA 0: 2 devices, NUMA 1: 4 devices, NUMA 2: 6 devices
+				// For allocation size 9, should use NUMA 0 (2) + NUMA 1 (4) + partial NUMA 2 (3)
+				numaConfigs := map[int][]int{
+					0: {2}, // NUMA 0: 2 devices
+					1: {4}, // NUMA 1: 4 devices
+					2: {6}, // NUMA 2: 6 devices
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 9)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(9))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				Expect(numaCount[2]).To(Equal(6), "Should use all 6 devices from NUMA 2")
+				Expect(numaCount[1]).To(Equal(3), "Should use 3 devices from NUMA 1")
+				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+			})
+
+			It("should handle allocation with uneven NUMA distribution", func() {
+				// NUMA 0: 1 device, NUMA 1: 3 devices, NUMA 2: 10 devices
+				// For allocation size 12, should use 1 + 3 + 6 devices (limited by NumaNodeDeviceCount=6)
+				numaConfigs := map[int][]int{
+					0: {1},    // NUMA 0: 1 device
+					1: {3},    // NUMA 1: 3 devices
+					2: {5, 5}, // NUMA 2: 10 devices
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 11)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(11))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				Expect(numaCount[2]).To(Equal(10), "Should use all 10 devices from NUMA 2")
+				Expect(numaCount[1]).To(Equal(1), "Should use all 1 device from NUMA 1")
+				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+			})
+
+			It("should verify device selection order within cross-NUMA allocation", func() {
+				// NUMA 0: 2 devices, NUMA 1: 5 devices
+				// For allocation size 7 (> 6), should prefer NUMA 0 entirely + 5 from NUMA 1
+				numaConfigs := map[int][]int{
+					0: {2}, // NUMA 0: 2 devices
+					1: {5}, // NUMA 1: 5 devices
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 7)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(7))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				// Should exhaust smaller NUMA first
+				Expect(numaCount[1]).To(Equal(5), "Should use all 5 devices from NUMA 1")
+				Expect(numaCount[0]).To(Equal(2), "Should use all 2 devices from NUMA 0")
+			})
+		})
+
+		Context("when single NUMA can satisfy allocation", func() {
+			It("should not trigger cross-NUMA allocation", func() {
+				// NUMA 0: 4 devices, NUMA 1: 6 devices
+				// For allocation size 5 (< 8), should use single NUMA allocation
+				numaConfigs := map[int][]int{
+					0: {4}, // NUMA 0: 4 devices
+					1: {6}, // NUMA 1: 6 devices
+				}
+				allocator := createTestTopologyWithMultipleNUMA(numaConfigs)
+
+				result, err := allocator.SelectDevices([]string{}, 5)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(5))
+
+				numaCount := countDevicesPerNUMA(result)
+
+				// Should use only one NUMA node (the one with 6 devices can satisfy 5)
+				usedNUMACount := 0
+				for _, count := range numaCount {
+					if count > 0 {
+						usedNUMACount++
+					}
+				}
+				Expect(usedNUMACount).To(Equal(1), "Should use only one NUMA node for allocation <= NumaNodeDeviceCount")
+			})
+		})
+	})
+
 	Describe("Error Scenarios", func() {
 		Context("when insufficient devices are available", func() {
 			It("should return error for allocation exceeding total capacity", func() {
@@ -220,6 +398,78 @@ var _ = Describe("TopologyAllocator", func() {
 				Expect(result).To(BeNil())
 				// NUMA 노드 레벨에서 먼저 실패하므로 해당 에러 메시지 확인
 				Expect(err.Error()).To(ContainSubstring("no NUMA node with sufficient devices"))
+			})
+		})
+
+		Context("when AllowCrossNuma is false and single NUMA cannot satisfy allocation", func() {
+			It("should return CrossNUMAAllocationError when allocation size exceeds single NUMA capacity", func() {
+				// NUMA 0: 3 devices, NUMA 1: 4 devices (total 7 devices available)
+				// Request 5 devices (> 4 max per NUMA), but AllowCrossNuma = false
+				numaConfigs := map[int][]int{
+					0: {3}, // NUMA 0: 3 devices
+					1: {4}, // NUMA 1: 4 devices
+				}
+				allocator := createTestTopologyWithCrossNUMA(numaConfigs, false)
+
+				result, err := allocator.SelectDevices([]string{}, 5)
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(err).To(BeAssignableToTypeOf(&CrossNUMAAllocationError{}))
+				Expect(err.Error()).To(ContainSubstring("cross-NUMA allocation not possible"))
+			})
+
+			It("should return CrossNUMAAllocationError when no single NUMA has enough devices", func() {
+				// NUMA 0: 2 devices, NUMA 1: 3 devices (total 5 devices available)
+				// Request 4 devices, but no single NUMA has 4 devices
+				numaConfigs := map[int][]int{
+					0: {2}, // NUMA 0: 2 devices
+					1: {3}, // NUMA 1: 3 devices
+				}
+				allocator := createTestTopologyWithCrossNUMA(numaConfigs, false)
+
+				result, err := allocator.SelectDevices([]string{}, 4)
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(err).To(BeAssignableToTypeOf(&CrossNUMAAllocationError{}))
+				Expect(err.Error()).To(ContainSubstring("cross-NUMA allocation not possible"))
+			})
+		})
+	})
+
+	Describe("AllowCrossNuma Configuration", func() {
+		Context("when AllowCrossNuma is false", func() {
+			It("should succeed when single NUMA can satisfy allocation", func() {
+				// NUMA 0: 3 devices, NUMA 1: 5 devices
+				// Request 4 devices, NUMA 1 can satisfy (5 >= 4)
+				numaConfigs := map[int][]int{
+					0: {3}, // NUMA 0: 3 devices
+					1: {5}, // NUMA 1: 5 devices
+				}
+				allocator := createTestTopologyWithCrossNUMA(numaConfigs, false)
+
+				result, err := allocator.SelectDevices([]string{}, 4)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(4))
+			})
+		})
+
+		Context("when AllowCrossNuma is true", func() {
+			It("should succeed when single NUMA cannot satisfy but cross-NUMA is allowed", func() {
+				// NUMA 0: 3 devices, NUMA 1: 4 devices (total 7 devices available)
+				// Request 5 devices (> 4 max per NUMA), but AllowCrossNuma = true
+				numaConfigs := map[int][]int{
+					0: {3}, // NUMA 0: 3 devices
+					1: {4}, // NUMA 1: 4 devices
+				}
+				allocator := createTestTopologyWithCrossNUMA(numaConfigs, true)
+
+				result, err := allocator.SelectDevices([]string{}, 5)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(5))
 			})
 		})
 	})

--- a/pkg/resources/topology_allocator_test.go
+++ b/pkg/resources/topology_allocator_test.go
@@ -266,9 +266,9 @@ var _ = Describe("TopologyAllocator", func() {
 				numaCount := countDevicesPerNUMA(result)
 
 				// Should use all 4 devices from NUMA 0 (smallest), then 6 from NUMA 1
-				Expect(numaCount[2]).To(Equal(8), "Should use all devices from NUMA 2")
-				Expect(numaCount[1]).To(Equal(2), "Should use 2 devices from NUMA 1")
-				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+				Expect(numaCount[0]).To(Equal(4), "Should use all devices from smallest NUMA 0 first")
+				Expect(numaCount[1]).To(Equal(6), "Should use remaining devices from NUMA 1")
+				Expect(numaCount[2]).To(Equal(0), "Should not use devices from largest NUMA 2")
 			})
 
 			It("should handle exact cross-NUMA allocation", func() {
@@ -308,9 +308,9 @@ var _ = Describe("TopologyAllocator", func() {
 
 				numaCount := countDevicesPerNUMA(result)
 
-				Expect(numaCount[2]).To(Equal(6), "Should use all 6 devices from NUMA 2")
-				Expect(numaCount[1]).To(Equal(3), "Should use 3 devices from NUMA 1")
-				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+				Expect(numaCount[0]).To(Equal(2), "Should use all devices from smallest NUMA 0 first")
+				Expect(numaCount[1]).To(Equal(4), "Should use all devices from next smallest NUMA 1")
+				Expect(numaCount[2]).To(Equal(3), "Should use remaining devices from largest NUMA 2")
 			})
 
 			It("should handle allocation with uneven NUMA distribution", func() {
@@ -330,9 +330,9 @@ var _ = Describe("TopologyAllocator", func() {
 
 				numaCount := countDevicesPerNUMA(result)
 
-				Expect(numaCount[2]).To(Equal(10), "Should use all 10 devices from NUMA 2")
-				Expect(numaCount[1]).To(Equal(1), "Should use all 1 device from NUMA 1")
-				Expect(numaCount[0]).To(Equal(0), "Should not use devices from NUMA 0")
+				Expect(numaCount[0]).To(Equal(1), "Should use all devices from smallest NUMA 0 first")
+				Expect(numaCount[1]).To(Equal(3), "Should use all devices from next smallest NUMA 1")
+				Expect(numaCount[2]).To(Equal(7), "Should use remaining devices from largest NUMA 2")
 			})
 
 			It("should verify device selection order within cross-NUMA allocation", func() {

--- a/pkg/resources/topology_allocator_test.go
+++ b/pkg/resources/topology_allocator_test.go
@@ -1,0 +1,188 @@
+package resources_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rebellions-sw/rebel-k8s-device-plugin/pkg/resources"
+)
+
+var _ = Describe("TopologyAllocator", func() {
+	var (
+		// Test fixture data based on the provided topology
+		availableDeviceIDs  []string
+		mockDeviceNUMANodes map[string]int
+		mockDeviceBridges   map[string]string
+	)
+
+	BeforeEach(func() {
+		availableDeviceIDs = []string{
+			// NUMA node 0, bridge 0000:02:00.0
+			"0000:08:00.0", "0000:07:00.0", "0000:06:00.0", "0000:05:00.0",
+			// NUMA node 0, bridge 0000:02:01.0
+			"0000:0c:00.0", "0000:0f:00.0", "0000:0e:00.0", "0000:0d:00.0",
+			// NUMA node 0, bridge 0000:42:01.0
+			"0000:49:00.0", "0000:48:00.0", "0000:47:00.0", "0000:46:00.0",
+			// NUMA node 0, bridge 0000:42:02.0
+			"0000:4f:00.0", "0000:4e:00.0", "0000:50:00.0", "0000:4d:00.0",
+			// NUMA node 1, bridge 0000:c2:00.0
+			"0000:c8:00.0", "0000:c7:00.0", "0000:c6:00.0", "0000:c5:00.0",
+			// NUMA node 1, bridge 0000:c2:01.0
+			"0000:cd:00.0", "0000:cc:00.0", "0000:cf:00.0", "0000:ce:00.0",
+			// NUMA node 1, bridge 0000:82:00.0
+			"0000:85:00.0", "0000:88:00.0", "0000:87:00.0", "0000:86:00.0",
+			// NUMA node 1, bridge 0000:82:01.0
+			"0000:8e:00.0", "0000:8d:00.0", "0000:8c:00.0", "0000:8f:00.0",
+		}
+
+		mockDeviceNUMANodes = map[string]int{
+			// NUMA node 0 devices
+			"0000:08:00.0": 0, "0000:07:00.0": 0, "0000:06:00.0": 0, "0000:05:00.0": 0,
+			"0000:0c:00.0": 0, "0000:0f:00.0": 0, "0000:0e:00.0": 0, "0000:0d:00.0": 0,
+			"0000:49:00.0": 0, "0000:48:00.0": 0, "0000:47:00.0": 0, "0000:46:00.0": 0,
+			"0000:4f:00.0": 0, "0000:4e:00.0": 0, "0000:50:00.0": 0, "0000:4d:00.0": 0,
+			// NUMA node 1 devices
+			"0000:c8:00.0": 1, "0000:c7:00.0": 1, "0000:c6:00.0": 1, "0000:c5:00.0": 1,
+			"0000:cd:00.0": 1, "0000:cc:00.0": 1, "0000:cf:00.0": 1, "0000:ce:00.0": 1,
+			"0000:85:00.0": 1, "0000:88:00.0": 1, "0000:87:00.0": 1, "0000:86:00.0": 1,
+			"0000:8e:00.0": 1, "0000:8d:00.0": 1, "0000:8c:00.0": 1, "0000:8f:00.0": 1,
+		}
+
+		mockDeviceBridges = map[string]string{
+			// NUMA node 0, bridge 0000:02:00.0
+			"0000:08:00.0": "0000:02:00.0", "0000:07:00.0": "0000:02:00.0",
+			"0000:06:00.0": "0000:02:00.0", "0000:05:00.0": "0000:02:00.0",
+			// NUMA node 0, bridge 0000:02:01.0
+			"0000:0c:00.0": "0000:02:01.0", "0000:0f:00.0": "0000:02:01.0",
+			"0000:0e:00.0": "0000:02:01.0", "0000:0d:00.0": "0000:02:01.0",
+			// NUMA node 0, bridge 0000:42:01.0
+			"0000:49:00.0": "0000:42:01.0", "0000:48:00.0": "0000:42:01.0",
+			"0000:47:00.0": "0000:42:01.0", "0000:46:00.0": "0000:42:01.0",
+			// NUMA node 0, bridge 0000:42:02.0
+			"0000:4f:00.0": "0000:42:02.0", "0000:4e:00.0": "0000:42:02.0",
+			"0000:50:00.0": "0000:42:02.0", "0000:4d:00.0": "0000:42:02.0",
+			// NUMA node 1, bridge 0000:c2:00.0
+			"0000:c8:00.0": "0000:c2:00.0", "0000:c7:00.0": "0000:c2:00.0",
+			"0000:c6:00.0": "0000:c2:00.0", "0000:c5:00.0": "0000:c2:00.0",
+			// NUMA node 1, bridge 0000:c2:01.0
+			"0000:cd:00.0": "0000:c2:01.0", "0000:cc:00.0": "0000:c2:01.0",
+			"0000:cf:00.0": "0000:c2:01.0", "0000:ce:00.0": "0000:c2:01.0",
+			// NUMA node 1, bridge 0000:82:00.0
+			"0000:85:00.0": "0000:82:00.0", "0000:88:00.0": "0000:82:00.0",
+			"0000:87:00.0": "0000:82:00.0", "0000:86:00.0": "0000:82:00.0",
+			// NUMA node 1, bridge 0000:82:01.0
+			"0000:8e:00.0": "0000:82:01.0", "0000:8d:00.0": "0000:82:01.0",
+			"0000:8c:00.0": "0000:82:01.0", "0000:8f:00.0": "0000:82:01.0",
+		}
+	})
+
+	// Create a test topology allocator with mocked data
+	createTestTopologyAllocator := func(deviceIDs []string) *resources.TopologyAllocator {
+		topology := &resources.NodeTopology{
+			NUMANodes: make(map[resources.NUMANode]*resources.NUMATopology),
+		}
+
+		for _, deviceID := range deviceIDs {
+			numaNode := mockDeviceNUMANodes[deviceID]
+			pciBridge := mockDeviceBridges[deviceID]
+
+			if _, exists := topology.NUMANodes[resources.NUMANode(numaNode)]; !exists {
+				topology.NUMANodes[resources.NUMANode(numaNode)] = &resources.NUMATopology{
+					PCIBridges: make(map[resources.BridgeID]*resources.PCIBridgeGroup),
+				}
+			}
+
+			if _, exists := topology.NUMANodes[resources.NUMANode(numaNode)].PCIBridges[resources.BridgeID(pciBridge)]; !exists {
+				topology.NUMANodes[resources.NUMANode(numaNode)].PCIBridges[resources.BridgeID(pciBridge)] = &resources.PCIBridgeGroup{
+					DeviceIDs: make([]string, 0),
+				}
+			}
+
+			topology.NUMANodes[resources.NUMANode(numaNode)].PCIBridges[resources.BridgeID(pciBridge)].DeviceIDs = append(
+				topology.NUMANodes[resources.NUMANode(numaNode)].PCIBridges[resources.BridgeID(pciBridge)].DeviceIDs,
+				deviceID,
+			)
+		}
+
+		return &resources.TopologyAllocator{NodeTopology: topology}
+	}
+
+	Describe("SelectDevices", func() {
+		Context("when devices are available on the same PCI Bridge", func() {
+			It("should select devices from the same bridge for allocation size 3", func() {
+				allocator := createTestTopologyAllocator(availableDeviceIDs)
+
+				result, err := allocator.SelectDevices([]string{}, 3)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(3))
+
+				// Verify all selected devices are from the same bridge
+				// Since we have 4 devices per bridge, allocation size 3 should work
+				firstDeviceBridge := mockDeviceBridges[result[0]]
+				for _, deviceID := range result {
+					Expect(mockDeviceBridges[deviceID]).To(Equal(firstDeviceBridge))
+				}
+			})
+
+			It("should select devices from the same bridge for allocation size equal to bridge capacity", func() {
+				allocator := createTestTopologyAllocator(availableDeviceIDs)
+
+				result, err := allocator.SelectDevices([]string{}, 4)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(4))
+
+				// Verify all selected devices are from the same bridge
+				firstDeviceBridge := mockDeviceBridges[result[0]]
+				for _, deviceID := range result {
+					Expect(mockDeviceBridges[deviceID]).To(Equal(firstDeviceBridge))
+				}
+			})
+		})
+
+		Context("when devices are available on the same NUMA node but not on single bridge", func() {
+			It("should select devices from the same NUMA node for allocation size 10", func() {
+				allocator := createTestTopologyAllocator(availableDeviceIDs)
+
+				result, err := allocator.SelectDevices([]string{}, 10)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(10))
+
+				// Verify all selected devices are from the same NUMA node
+				// Since we have 16 devices per NUMA node, allocation size 10 should work
+				firstDeviceNUMA := mockDeviceNUMANodes[result[0]]
+				for _, deviceID := range result {
+					Expect(mockDeviceNUMANodes[deviceID]).To(Equal(firstDeviceNUMA))
+				}
+			})
+
+			It("should select devices from the same NUMA node for allocation size equal to NUMA node capacity", func() {
+				allocator := createTestTopologyAllocator(availableDeviceIDs)
+
+				result, err := allocator.SelectDevices([]string{}, 16)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(16))
+
+				// Verify all selected devices are from the same NUMA node
+				firstDeviceNUMA := mockDeviceNUMANodes[result[0]]
+				for _, deviceID := range result {
+					Expect(mockDeviceNUMANodes[deviceID]).To(Equal(firstDeviceNUMA))
+				}
+			})
+		})
+
+		Context("when insufficient devices are available for topology-aware allocation", func() {
+			It("should return error for allocation size 20", func() {
+				allocator := createTestTopologyAllocator(availableDeviceIDs)
+
+				result, err := allocator.SelectDevices([]string{}, 20)
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+				Expect(err.Error()).To(ContainSubstring("insufficient devices for topology-aware allocation"))
+			})
+		})
+	})
+})

--- a/pkg/types/mocks/ResourceFactory.go
+++ b/pkg/types/mocks/ResourceFactory.go
@@ -173,9 +173,9 @@ func (_m *ResourceFactory) GetResourcePool(rc *types.ResourceConfig, deviceList 
 	return r0, r1
 }
 
-// GetResourceServer provides a mock function with given fields: _a0
-func (_m *ResourceFactory) GetResourceServer(_a0 types.ResourcePool) (types.ResourceServer, error) {
-	ret := _m.Called(_a0)
+// GetResourceServer provides a mock function with given fields: _a0, _a1
+func (_m *ResourceFactory) GetResourceServer(_a0 types.ResourcePool, _a1 *types.ResourceConfig) (types.ResourceServer, error) {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetResourceServer")
@@ -183,19 +183,16 @@ func (_m *ResourceFactory) GetResourceServer(_a0 types.ResourcePool) (types.Reso
 
 	var r0 types.ResourceServer
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.ResourcePool) (types.ResourceServer, error)); ok {
-		return rf(_a0)
-	}
-	if rf, ok := ret.Get(0).(func(types.ResourcePool) types.ResourceServer); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(types.ResourcePool, *types.ResourceConfig) types.ResourceServer); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.ResourceServer)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(types.ResourcePool) error); ok {
-		r1 = rf(_a0)
+	if rf, ok := ret.Get(1).(func(types.ResourcePool, *types.ResourceConfig) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,6 +99,7 @@ type ResourceConfig struct {
 	ResourceName    string                    `json:"resourceName"` // the resource name will be added with resource prefix in K8s api
 	DeviceType      DeviceType                `json:"deviceType,omitempty"`
 	ExcludeTopology bool                      `json:"excludeTopology,omitempty"`
+	AllowCrossNuma  bool                      `json:"allowCrossNuma,omitempty"`
 	Selectors       *json.RawMessage          `json:"selectors,omitempty"`
 	AdditionalInfo  map[string]AdditionalInfo `json:"additionalInfo,omitempty"`
 	SelectorObjs    []interface{}
@@ -172,7 +173,7 @@ type ResourceServer interface {
 
 // ResourceFactory is an interface to get instances of ResourcePool and ResourceServer
 type ResourceFactory interface {
-	GetResourceServer(ResourcePool) (ResourceServer, error)
+	GetResourceServer(ResourcePool, *ResourceConfig) (ResourceServer, error)
 	GetDefaultInfoProvider(string, string) []DeviceInfoProvider
 	GetSelector(string, []string) (DeviceSelector, error)
 	GetResourcePool(rc *ResourceConfig, deviceList []HostDevice) (ResourcePool, error)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -575,9 +575,7 @@ func GetPKey(pciAddr string) (string, error) {
 }
 
 // GetPCIBridge returns the 2nd PCI bridge in the hierarchy (0=root-port, 1=1st bridge, 2=2nd bridge)
-func GetPCIBridge(pciAddr string) (string, error) {
-	const secondBridgeIndex = 2
-
+func GetPCIBridge(pciAddr string, bridgeIndex int) (string, error) {
 	// Resolve the real sysfs path of the PCI device
 	devicePath := filepath.Join(sysBusPci, pciAddr)
 	realPath, err := filepath.EvalSymlinks(devicePath)
@@ -585,7 +583,7 @@ func GetPCIBridge(pciAddr string) (string, error) {
 		return "", fmt.Errorf("failed to resolve PCI device symlinks: %w", err)
 	}
 
-	pciBridge, err := ExtractPCIBridgeFromPath(realPath, secondBridgeIndex)
+	pciBridge, err := ExtractPCIBridgeFromPath(realPath, bridgeIndex)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -598,6 +598,22 @@ var _ = Describe("In the utils package", func() {
 		Entry("valid deviceID string", "driver_name.type.123", "type"),
 	)
 
+	DescribeTable("extracting PCI bridge from path",
+		func(realPath string, bridgeIndex int, expected string, shouldFail bool) {
+			actual, err := ExtractPCIBridgeFromPath(realPath, bridgeIndex)
+			Expect(actual).To(Equal(expected))
+			assertShouldFail(err, shouldFail)
+		},
+		Entry("successfully extracting 2nd bridge from valid path",
+			"/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/0000:04:00.0/0000:05:00.0",
+			2, "0000:02:00.0", false,
+		),
+		Entry("failing to extract 2nd bridge from insufficient hierarchy",
+			"/sys/devices/pci0000:17/0000:17:02.0/0000:18:00.0",
+			2, "", true,
+		),
+	)
+
 	Context("GetPfNameFromAuxDev", func() {
 		var (
 			mockSriovnet *mocks.SriovnetProvider


### PR DESCRIPTION
## Summary
### Device Selection Process
1. **Device Type Check**  
   Verify if the device pool contains Rebellions NPU devices (vendor ID `1eff`)

2. **Product Type Selection**  
   Determine allocation strategy based on product ID:  
   - **TopologyAllocator**: For supported products (`1250`, `1251`, `1220`, `1221`)  
   - **KubeletDelegatingAllocator**: For other products (fall back to kubelet)

3. **Cross-NUMA Condition Check**  
   Trigger Cross-NUMA allocation when:  
   - Allocation size exceeds single NUMA capacity (`allocationSize > NumaNodeDeviceCount`)  
   - Cross-NUMA is explicitly enabled (`AllowCrossNuma = true`)

   3.1. **Cross-NUMA Allocation** (when triggered)  
   - Sort NUMA nodes by device count (ascending)  
   - Allocate from small NUMA nodes first  
   - Apply bridge-based allocation within each NUMA

4. **Single NUMA Selection**  
   Find the optimal NUMA node with sufficient devices for the allocation

   4.1. **Bridge-based Allocation** (within the selected NUMA node)  
   - **Bridge minimization**: Use the minimum number of PCI bridges  
   - **Full fill priority**: Maximize devices allocated per bridge  
   - **Device remaining optimization**: Minimize fragmentation


## Key Changes
**TopologyAllocator (pkg/resources/topology_allocator.go)**
- Picks same-bridge first, then same-NUMA, errors if not enough devices
- Cross-NUMA allocation with smart prioritization (smaller NUMA nodes first)
- Configurable cross-NUMA support via `allowCrossNuma` field

**ResourceServer (pkg/resources/server.go)**
- Implements GetPreferredAllocation RPC using TopologyAllocator
- Leaves non-Rebellions devices to kubelet’s default
- Passes ResourceConfig to allocation logic for configuration-driven behavior

**Utils (pkg/utils/utils.go)**
- PCI bridge extraction from device address/path