### PR TITLE
fix: sort CA25 device BDF in ascending order to prevent driver conflicts

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -133,26 +134,30 @@ func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateR
 	for _, container := range rqt.ContainerRequests {
 		containerResp := new(pluginapi.ContainerAllocateResponse)
 
-		envs, err := rs.getEnvs(container.DevicesIDs)
+		deviceIDs := make([]string, len(container.DevicesIDs))
+		copy(deviceIDs, container.DevicesIDs)
+		sort.Strings(deviceIDs)
+
+		envs, err := rs.getEnvs(deviceIDs)
 		if err != nil {
-			glog.Errorf("failed to get environment variables for device IDs %v: %v", container.DevicesIDs, err)
+			glog.Errorf("failed to get environment variables for device IDs %v: %v", deviceIDs, err)
 			return nil, err
 		}
 
 		if rs.useCdi {
 			containerResp.Annotations, err = rs.cdi.CreateContainerAnnotations(
-				container.DevicesIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
+				deviceIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
 			if err != nil {
 				return nil, fmt.Errorf("can't create container annotation: %s", err)
 			}
 		} else {
-			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(container.DevicesIDs)
-			containerResp.Mounts = rs.resourcePool.GetMounts(container.DevicesIDs)
+			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(deviceIDs)
+			containerResp.Mounts = rs.resourcePool.GetMounts(deviceIDs)
 		}
 
-		err = rs.resourcePool.StoreDeviceInfoFile(rs.resourceNamePrefix, container.DevicesIDs)
+		err = rs.resourcePool.StoreDeviceInfoFile(rs.resourceNamePrefix, deviceIDs)
 		if err != nil {
-			glog.Errorf("failed to store device info file for device IDs %v: %v", container.DevicesIDs, err)
+			glog.Errorf("failed to store device info file for device IDs %v: %v", deviceIDs, err)
 			return nil, err
 		}
 


### PR DESCRIPTION
## Summary
This PR implements BDF (Bus-Device-Function) sorting for CA25 cards in the sandbox-plugin to ensure devices are allocated in a predictable order, preventing potential driver conflicts during device recognition.

### Problem
In the current implementation, device IDs are not sorted consistently, which can lead to:
- Driver conflicts during device initialization

### Solution
- Added BDF-based sorting for CA25 device allocation