### PR TITLE
feat: create RSD group on device allocation

### DIFF
--- a/deployments/rbln/daemonset.yaml
+++ b/deployments/rbln/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
             - --log-level=10
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
               cpu: "250m"
@@ -65,6 +66,13 @@ spec:
               mountPath: /etc/pcidp
             - name: device-info
               mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
+            - name: host-usr-local-bin
+              mountPath: /usr/local/bin
+              readOnly: true
+            - name: host-dev
+              mountPath: /dev
+            - name: host-sys
+              mountPath: /sys
       volumes:
         - name: devicesock
           hostPath:
@@ -85,3 +93,15 @@ spec:
             items:
               - key: config.json
                 path: config.json
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: host-dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: host-usr-local-bin
+          hostPath:
+            path: /usr/local/bin
+            type: Directory

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.3.0
+	golang.org/x/sys v0.25.0
 	google.golang.org/grpc v1.67.1
 	k8s.io/kubelet v0.31.1
 )
@@ -59,7 +60,6 @@ require (
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
-	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -7,6 +7,7 @@ ENV HTTPS_PROXY $https_proxy
 RUN apk add --no-cache --virtual build-dependencies build-base
 
 WORKDIR /usr/src/sriov-network-device-plugin
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN make clean && \
     make build
 
@@ -21,16 +22,21 @@ RUN apk add --no-cache --virtual build-dependencies build-base linux-headers
 WORKDIR /tmp/ddptool
 RUN make
 
-FROM alpine:3
-RUN apk add --no-cache hwdata-pci
-COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
+FROM redhat/ubi9-minimal:9.6
+
+RUN microdnf install -y \
+      pciutils-3.7.0-7.el9 \
+      hwdata-0.348-9.18.el9 \
+  && microdnf clean all
+
+COPY --from=builder     /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=ddp-builder /tmp/ddptool/ddptool /usr/bin/
+
+COPY ./images/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 WORKDIR /
 
-LABEL io.k8s.display-name="SRIOV Network Device Plugin"
-
-COPY ./images/entrypoint.sh /
-
-RUN rm -rf /var/cache/apk/*
+LABEL io.k8s.display-name="SRIOV Network Device Plugin (UBI9)"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pkg/accelerator/accelResourcePool.go
+++ b/pkg/accelerator/accelResourcePool.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	accelPoolType = "net-accel"
+	accelPoolType  = "net-accel"
+	rblnDriverName = "rebellions"
 )
 
 type accelResourcePool struct {
@@ -61,13 +62,15 @@ func (rp *accelResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Dev
 		}
 	}
 
-	rsdGroupDevice := utils.RecreateRsdGroup(deviceIDs)
-	glog.Infof("RSD group device: %s", rsdGroupDevice)
-	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
-		HostPath:      rsdGroupDevice,
-		ContainerPath: rsdGroupDevice,
-		Permissions:   "rw",
-	})
+	if devicePool[deviceIDs[0]].GetDriver() == rblnDriverName {
+		rsdGroupDevice := utils.RecreateRsdGroup(deviceIDs)
+		glog.Infof("RSD group device: %s", rsdGroupDevice)
+		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
+			HostPath:      rsdGroupDevice,
+			ContainerPath: rsdGroupDevice,
+			Permissions:   "rw",
+		})
+	}
 
 	return devSpecs
 }

--- a/pkg/accelerator/accelResourcePool.go
+++ b/pkg/accelerator/accelResourcePool.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rebellions-sw/rbln-k8s-device-plugin/pkg/resources"
 	"github.com/rebellions-sw/rbln-k8s-device-plugin/pkg/types"
+	"github.com/rebellions-sw/rbln-k8s-device-plugin/pkg/utils"
 )
 
 const (
@@ -59,6 +60,15 @@ func (rp *accelResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Dev
 			}
 		}
 	}
+
+	rsdGroupDevice := utils.RecreateRsdGroup(deviceIDs)
+	glog.Infof("RSD group device: %s", rsdGroupDevice)
+	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
+		HostPath:      rsdGroupDevice,
+		ContainerPath: rsdGroupDevice,
+		Permissions:   "rw",
+	})
+
 	return devSpecs
 }
 

--- a/pkg/accelerator/accelResourcePool_test.go
+++ b/pkg/accelerator/accelResourcePool_test.go
@@ -72,7 +72,7 @@ var _ = Describe("AccelResourcePool", func() {
 
 			It("should return valid slice of device specs", func() {
 				Expect(actual).ToNot(BeNil())
-				Expect(actual).To(HaveLen(3)) // fake1 + fake2 => 3 devices
+				Expect(actual).To(HaveLen(4)) // fake1 + fake2 + rsd0 => 4 devices
 				Expect(actual).To(ContainElement(fake1ds[0]))
 				Expect(actual).To(ContainElement(fake1ds[1]))
 				Expect(actual).To(ContainElement(fake2ds[0]))

--- a/pkg/infoprovider/rebellionsInfoProvider.go
+++ b/pkg/infoprovider/rebellionsInfoProvider.go
@@ -17,7 +17,6 @@ const (
 	RebellionsVendorID = "1eff"
 	SysfsDriverPools   = "/sys/bus/pci/drivers/rebellions/%s/pools"
 	CharDeviceNode     = "/dev/%s"
-	RsdNode            = "/dev/rsd0"
 )
 
 type rebellionsInfoProvider struct {
@@ -61,10 +60,6 @@ func (rp *rebellionsInfoProvider) GetDeviceSpecs() []*pluginapi.DeviceSpec {
 	devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 		HostPath:      devicePath,
 		ContainerPath: devicePath,
-		Permissions:   "rw",
-	}, &pluginapi.DeviceSpec{
-		HostPath:      RsdNode,
-		ContainerPath: RsdNode,
 		Permissions:   "rw",
 	})
 	return devSpecs

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -134,30 +134,28 @@ func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateR
 	for _, container := range rqt.ContainerRequests {
 		containerResp := new(pluginapi.ContainerAllocateResponse)
 
-		deviceIDs := make([]string, len(container.DevicesIDs))
-		copy(deviceIDs, container.DevicesIDs)
-		sort.Strings(deviceIDs)
+		sort.Strings(container.DevicesIDs)
 
-		envs, err := rs.getEnvs(deviceIDs)
+		envs, err := rs.getEnvs(container.DevicesIDs)
 		if err != nil {
-			glog.Errorf("failed to get environment variables for device IDs %v: %v", deviceIDs, err)
+			glog.Errorf("failed to get environment variables for device IDs %v: %v", container.DevicesIDs, err)
 			return nil, err
 		}
 
 		if rs.useCdi {
 			containerResp.Annotations, err = rs.cdi.CreateContainerAnnotations(
-				deviceIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
+				container.DevicesIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
 			if err != nil {
 				return nil, fmt.Errorf("can't create container annotation: %s", err)
 			}
 		} else {
-			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(deviceIDs)
-			containerResp.Mounts = rs.resourcePool.GetMounts(deviceIDs)
+			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(container.DevicesIDs)
+			containerResp.Mounts = rs.resourcePool.GetMounts(container.DevicesIDs)
 		}
 
-		err = rs.resourcePool.StoreDeviceInfoFile(rs.resourceNamePrefix, deviceIDs)
+		err = rs.resourcePool.StoreDeviceInfoFile(rs.resourceNamePrefix, container.DevicesIDs)
 		if err != nil {
-			glog.Errorf("failed to store device info file for device IDs %v: %v", deviceIDs, err)
+			glog.Errorf("failed to store device info file for device IDs %v: %v", container.DevicesIDs, err)
 			return nil, err
 		}
 

--- a/pkg/utils/rbln_smi.go
+++ b/pkg/utils/rbln_smi.go
@@ -1,0 +1,276 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/sys/unix"
+)
+
+type RblnSmi struct {
+	KMDVersion string   `json:"KMD_version"`
+	Devices    []Device `json:"devices"`
+}
+
+type Device struct {
+	GroupID string  `json:"group_id"`
+	Npu     int     `json:"npu"`
+	Name    string  `json:"name"`
+	SID     string  `json:"sid"`
+	Device  string  `json:"device"`
+	PCI     PCIInfo `json:"pci"`
+}
+
+type PCIInfo struct {
+	Dev      string `json:"dev"`
+	BusID    string `json:"bus_id"`
+	NUMANode string `json:"numa_node"`
+}
+
+const (
+	rblnSmiCommand     = "rbln-smi"
+	rblnSmiGroupOption = "group"
+	defaultExecTimeout = 5 * time.Second
+	defaultGroupID     = "0"
+	rblnSmiLockFile    = "/var/run/rbln-device-plugin.lock"
+	rsdDevice          = "/dev/rsd"
+	defaultRsdDevice   = rsdDevice + "0"
+	lockFilePerm       = 0o644
+	lockPollInterval   = 100 * time.Millisecond
+)
+
+func getRblnSmiAbsolutePath() (string, error) {
+	abs, err := exec.LookPath(rblnSmiCommand)
+	if err != nil {
+		return "", fmt.Errorf("cannot find %s command: %w", rblnSmiCommand, err)
+	}
+	return abs, nil
+}
+
+func runRblnSmiCommand(args ...string) ([]byte, error) {
+	abs, err := getRblnSmiAbsolutePath()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultExecTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, abs, args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			status := ee.Sys().(syscall.WaitStatus)
+			return nil, fmt.Errorf("command failed with exit code %d: %s", status.ExitStatus(), string(out))
+		}
+		return nil, fmt.Errorf("failed to start command: %w", err)
+	}
+	return out, nil
+}
+
+func getDeviceInfoFromRblnSmi() (*RblnSmi, error) {
+	out, err := runRblnSmiCommand("-g", "-j")
+	if err != nil {
+		return nil, err
+	}
+	var result RblnSmi
+	if err = json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal rbln-smi output: %w", err)
+	}
+	return &result, nil
+}
+
+func collectRsdGroupIDs(smiInfo *RblnSmi, devices []string) []string {
+	var filterdDevices []Device
+
+	if len(devices) == 0 {
+		filterdDevices = smiInfo.Devices
+	} else {
+		deviceSet := make(map[string]struct{}, len(devices))
+		for _, device := range devices {
+			deviceSet[device] = struct{}{}
+		}
+
+		for _, v := range smiInfo.Devices {
+			if _, ok := deviceSet[v.PCI.BusID]; ok {
+				filterdDevices = append(filterdDevices, v)
+			}
+		}
+	}
+
+	seen := make(map[string]struct{})
+	groupIDs := make([]string, 0, len(filterdDevices))
+	for _, fd := range filterdDevices {
+		if fd.GroupID == defaultGroupID {
+			continue
+		}
+		if _, exists := seen[fd.GroupID]; !exists {
+			seen[fd.GroupID] = struct{}{}
+			groupIDs = append(groupIDs, fd.GroupID)
+		}
+	}
+	return groupIDs
+}
+
+func getRsdGroupIDs(smiInfo *RblnSmi, devices []string) []string {
+	return collectRsdGroupIDs(smiInfo, devices)
+}
+
+func getAllRsdGroupIDs(smiInfo *RblnSmi) []string {
+	return collectRsdGroupIDs(smiInfo, nil)
+}
+
+func getNpuIDs(smiInfo *RblnSmi, devices []string) []int {
+	var npuIDs []int
+
+	for _, device := range devices {
+		for _, v := range smiInfo.Devices {
+			if v.PCI.BusID == device {
+				npuIDs = append(npuIDs, v.Npu)
+			}
+		}
+	}
+	return npuIDs
+}
+
+func nextRsdGroupID(smiInfo *RblnSmi) (string, error) {
+	groupIDs := getAllRsdGroupIDs(smiInfo)
+
+	seen := make(map[int]struct{}, len(groupIDs))
+
+	for _, s := range groupIDs {
+		groupID, err := strconv.Atoi(s)
+		if err != nil {
+			return "", fmt.Errorf("invalid group id: %d", groupID)
+		}
+		seen[groupID] = struct{}{}
+	}
+
+	for i := 1; ; i++ {
+		if _, ok := seen[i]; !ok {
+			return strconv.Itoa(i), nil
+		}
+	}
+}
+
+func acquireFileLock(ctx context.Context, lockPath string) (release func() error, err error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, lockFilePerm)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	unlock := func() error {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		return f.Close()
+	}
+
+	ticker := time.NewTicker(lockPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, fmt.Errorf("acquire lock timeout/canceled: %w", ctx.Err())
+		default:
+			if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+				<-ticker.C
+				continue
+			}
+			return unlock, nil
+		}
+	}
+}
+
+func destroyRsdGroup(deviceIDs []string) error {
+	smiInfo, err := getDeviceInfoFromRblnSmi()
+	if err != nil {
+		return err
+	}
+
+	groupIDs := getRsdGroupIDs(smiInfo, deviceIDs)
+	if err != nil {
+		return err
+	}
+	if len(groupIDs) > 0 {
+		_, err = runRblnSmiCommand(rblnSmiGroupOption, "-d", strings.Join(groupIDs, ","))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createRsdGroup(devices []string) (groupID string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultExecTimeout)
+	defer cancel()
+
+	release, err := acquireFileLock(ctx, rblnSmiLockFile)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		releaseErr := release()
+		if err == nil && releaseErr != nil {
+			err = releaseErr
+			groupID = ""
+		}
+	}()
+
+	smiInfo, err := getDeviceInfoFromRblnSmi()
+	if err != nil {
+		return "", err
+	}
+
+	groupID, err = nextRsdGroupID(smiInfo)
+	if err != nil {
+		return "", err
+	}
+
+	npuIDs := getNpuIDs(smiInfo, devices)
+
+	strIDs := make([]string, len(npuIDs))
+	for i, id := range npuIDs {
+		strIDs[i] = strconv.Itoa(id)
+	}
+
+	_, err = runRblnSmiCommand(
+		rblnSmiGroupOption,
+		"-c", groupID,
+		"-a", strings.Join(strIDs, ","),
+	)
+
+	if err != nil {
+		return "", err
+	}
+	return groupID, nil
+}
+
+func RecreateRsdGroup(deviceIDs []string) string {
+	var groupID string
+	err := destroyRsdGroup(deviceIDs)
+	if err != nil {
+		glog.Errorf("Failed to destroy RSD groups: %q", err)
+		return defaultRsdDevice
+	}
+
+	groupID, err = createRsdGroup(deviceIDs)
+
+	if err != nil {
+		glog.Errorf("Failed to create RSD groups: %q", err)
+		return defaultRsdDevice
+	}
+	return rsdDevice + groupID
+}


### PR DESCRIPTION
This PR updates the Allocate logic to:

- Sort container.DevicesIDs in place for deterministic ordering.
- Create an RSD group via rbln-smi binary execution file.
- Append corresponding /dev/rsdx* device specs to the container response.