### PR TITLE
feat: mount RSD group device to fixed container path (/dev/rsd0)

### DIFF
--- a/pkg/accelerator/accelResourcePool.go
+++ b/pkg/accelerator/accelResourcePool.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	accelPoolType  = "net-accel"
-	rblnDriverName = "rebellions"
+	accelPoolType    = "net-accel"
+	rblnDriverName   = "rebellions"
+	containerRsdPath = "/dev/rsd0"
 )
 
 type accelResourcePool struct {
@@ -67,7 +68,7 @@ func (rp *accelResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Dev
 		glog.Infof("RSD group device: %s", rsdGroupDevice)
 		devSpecs = append(devSpecs, &pluginapi.DeviceSpec{
 			HostPath:      rsdGroupDevice,
-			ContainerPath: rsdGroupDevice,
+			ContainerPath: containerRsdPath,
 			Permissions:   "rw",
 		})
 	}


### PR DESCRIPTION
This change updates the device plugin to mount the dynamically allocated RSD group device to a fixed container path (/dev/rsd0).  
Previously, the container used the same host path as the dynamically created group device (e.g., /dev/rsd1, /dev/rsd2), which caused inconsistent mount paths between containers.

Changes:
- Added `containerRsdPath = "/dev/rsd0"`
- Updated `ContainerPath` in DeviceSpec to use `containerRsdPath`

This ensures a consistent container-level device path while allowing dynamic RSD group creation on the host side.