### PR TITLE
feat(cdi): use runtime CDI annotations and host rbln-smi paths

### DIFF
--- a/deployments/rbln/configmap.yaml
+++ b/deployments/rbln/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: rbln-device-plugin-config
-  namespace: kube-system
+  namespace: rbln-system
 data:
   config.json: |
     {

--- a/deployments/rbln/daemonset.yaml
+++ b/deployments/rbln/daemonset.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rbln-device-plugin
-  namespace: kube-system
+  namespace: rbln-system
 
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: rbln-device-plugin
-  namespace: kube-system
+  namespace: rbln-system
   labels:
     tier: node
     app: rbln-device-plugin
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: rbln-device-plugin
       containers:
         - name: device-plugin
-          image: rebellions/k8s-device-plugin:v0.3.0
+          image: rebellions/k8s-device-plugin:v0.3.6
           imagePullPolicy: IfNotPresent
           args:
             - --log-dir=device-plugin
@@ -66,8 +66,11 @@ spec:
               mountPath: /etc/pcidp
             - name: device-info
               mountPath: /var/run/k8s.cni.cncf.io/devinfo/dp
-            - name: host-usr-local-bin
-              mountPath: /usr/local/bin
+            - name: host-usr-bin
+              mountPath: /host/usr/bin
+              readOnly: true
+            - name: host-driver-usr-bin
+              mountPath: /host/driver/usr/bin
               readOnly: true
             - name: host-dev
               mountPath: /dev
@@ -101,7 +104,11 @@ spec:
           hostPath:
             path: /dev
             type: Directory
-        - name: host-usr-local-bin
+        - name: host-usr-bin
           hostPath:
-            path: /usr/local/bin
+            path: /usr/bin
             type: Directory
+        - name: host-driver-usr-bin
+          hostPath:
+            path: /run/rbln/driver/usr/bin
+            type: DirectoryOrCreate

--- a/pkg/cdi/cdi.go
+++ b/pkg/cdi/cdi.go
@@ -37,6 +37,7 @@ const (
 	cdiCommonDeviceName = "common"
 	SysfsDriverPools    = "/sys/bus/pci/drivers/rebellions/%s/pools"
 	containerRsdPath    = "/dev/rsd0"
+	runtimeDeviceName   = "runtime"
 )
 
 // CDI represents CDI API required by Device plugin
@@ -124,6 +125,27 @@ func (c *impl) CreateContainerAnnotations(devicesIDs []string, resourcePrefix, r
 	}
 	annotations[annoKey] = annoValue
 
+	return annotations, nil
+}
+
+// CreateRuntimeAnnotations is a package-level helper that builds CDI annotations
+func CreateRuntimeAnnotations(resourcePrefix, resourceKind string) (map[string]string, error) {
+	annotations := make(map[string]string, 0)
+
+	annoKey, err := cdi.AnnotationKey(resourcePrefix, resourceKind)
+	if err != nil {
+		glog.Errorf("CreateRuntimeAnnotations(): can't create container annotation: %v", err)
+		return nil, err
+	}
+
+	runtimeDevice := cdi.QualifiedName(resourcePrefix, resourceKind, runtimeDeviceName)
+	annoValue, err := cdi.AnnotationValue([]string{runtimeDevice})
+	if err != nil {
+		glog.Errorf("CreateRuntimeAnnotations(): can't create container annotation: %v", err)
+		return nil, err
+	}
+
+	annotations[annoKey] = annoValue
 	return annotations, nil
 }
 

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -143,13 +143,11 @@ func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateR
 		}
 
 		if rs.useCdi {
-			containerResp.Annotations, err = rs.cdi.CreateContainerAnnotations(
-				container.DevicesIDs, rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
+			containerResp.Annotations, err = cdiPkg.CreateRuntimeAnnotations(rs.resourceNamePrefix, rs.resourcePool.GetCDIName())
 			if err != nil {
 				return nil, fmt.Errorf("can't create container annotation: %s", err)
 			}
-			containerResp.Devices = cdiPkg.CreateCdiDeviceSpecs(container.DevicesIDs)
-			containerResp.Mounts = rs.resourcePool.GetMounts(container.DevicesIDs)
+			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(container.DevicesIDs)
 		} else {
 			containerResp.Devices = rs.resourcePool.GetDeviceSpecs(container.DevicesIDs)
 			containerResp.Mounts = rs.resourcePool.GetMounts(container.DevicesIDs)

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Server", func() {
 				On("GetMounts", []string{"00:00.01"}).
 				Return([]*pluginapi.Mount{{ContainerPath: "/dev/fake", HostPath: "/dev/fake", ReadOnly: false}}).
 				On("GetCDIName").
-				Return("fake.com").
+				Return("fake").
 				On("StoreDeviceInfoFile", "fake.com", []string{"00:00.01"}).
 				Return(nil)
 

--- a/pkg/utils/rbln_smi.go
+++ b/pkg/utils/rbln_smi.go
@@ -49,9 +49,24 @@ const (
 )
 
 func getRblnSmiAbsolutePath() (string, error) {
+	// Prefer explicit driver/installed locations before falling back to PATH lookup.
+	candidates := []string{
+		"/usr/bin/rbln-smi",
+		"/run/rbln/driver/usr/bin/rbln-smi",
+		"/host/usr/bin/rbln-smi",
+		"/host/driver/usr/bin/rbln-smi",
+	}
+
+	for _, p := range candidates {
+		info, err := os.Stat(p)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return p, nil
+		}
+	}
+
 	abs, err := exec.LookPath(rblnSmiCommand)
 	if err != nil {
-		return "", fmt.Errorf("cannot find %s command: %w", rblnSmiCommand, err)
+		return "", fmt.Errorf("cannot find %s command in predefined paths or PATH: %w", rblnSmiCommand, err)
 	}
 	return abs, nil
 }


### PR DESCRIPTION
## Motivation
Ensure CDI runtime annotations work with the new runtime pseudo-device and make rbln-smi discoverable across host/driver paths without breaking container binaries.

## Summary of Changes
- Add runtime CDI annotation helper and use it in allocation flow.
- Update rbln-smi lookup and daemonset mounts to avoid /usr/bin collisions while supporting host/driver paths.